### PR TITLE
Fixed toKubernetesList function

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -240,13 +240,11 @@ toKubernetesList null [{ apiVersion = "v1"; kind = "Pod"; }] { metadata.name = "
 ----
 {
   # Turns a Nix list into a generic Kubernetes Resource List
-  toKubernetesList =
-    resourceType: items: overrides:
-    lib.attrsets.recursiveUpdate ({
-      apiVersion = "v1";
-      kind = ''${if resourceType != null then resourceType else ""}List'';
-      inherit items;
-  } (if overrides != null then overrides else {}));
+  toKubernetesList = resourceType: items: overrides: lib.attrsets.recursiveUpdate {
+    apiVersion = "v1";
+    kind = ''${if resourceType != null then resourceType else ""}List'';
+    inherit items;
+  } (if overrides != null then overrides else {});
 }
 ----
 ====

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -13,11 +13,11 @@ rec {
   helm = pkgs.callPackage ./helm.nix { inherit nixToYaml; };
 
   # Turns a Nix list into a generic Kubernetes Resource List
-  toKubernetesList = resourceType: items: overrides: lib.attrsets.recursiveUpdate ({
+  toKubernetesList = resourceType: items: overrides: lib.attrsets.recursiveUpdate {
     apiVersion = "v1";
     kind = ''${if resourceType != null then resourceType else ""}List'';
     inherit items;
-  } (if overrides != null then overrides else {}));
+  } (if overrides != null then overrides else {});
 
   keyValFromJsonManifest = args: wrapF args _keyValFromJsonManifest;
   # Takes a JSON kubernetes manifests and builds a key-value pair


### PR DESCRIPTION
Wrong and unneede parenthesis caused `toKubernetesList` to always return a `recursiveUpdate` lambda